### PR TITLE
Implement feature #6: ruleset serialization

### DIFF
--- a/data/serialize.go
+++ b/data/serialize.go
@@ -1,79 +1,230 @@
+// Functions and methods for reserializing the JSON into YARA rules.
+// TODO: Handle indents better... Maybe have a global var denoting
+// how many spaces to indent.
+// TODO: Handle indents and formatting in general for conditions.
+// Once conditions are treated as first-class vs. text, we can do that.
+
 package data
 
 import (
 	"fmt"
-	"io"
 	"strings"
 )
 
-// Serialize builds the Yara rule
-func (rule *Rule) Serialize(output io.Writer) {
-	if rule.Modifiers.Global {
-		fmt.Fprintf(output, "global ")
-	} else if rule.Modifiers.Private {
-		fmt.Fprintf(output, "private ")
-	}
+// Serialize for RuleSet builds a complete YARA ruleset
+func (rs *RuleSet) Serialize() (out string, err error) {
+	var b strings.Builder
 
-	fmt.Fprintf(output, "rule %s ", rule.Identifier)
-	if len(rule.Tags) > 0 {
-		fmt.Fprintf(output, ": %s ", strings.Join(rule.Tags, " "))
-	}
-
-	fmt.Fprintf(output, "{ \n")
-	if len(rule.Meta) > 0 {
-		fmt.Fprintf(output, "  meta:\n")
-		for _, meta := range rule.Meta {
-			if _, ok := meta.Val.(string); ok {
-				fmt.Fprintf(output, "    %s = \"%s\"\n", meta.Key, meta.Val)
-			}
-			if _, ok := meta.Val.(int64); ok {
-				fmt.Fprintf(output, "    %s = %d\n", meta.Key, meta.Val)
-			}
-			if val, ok := meta.Val.(bool); ok {
-				if val {
-					fmt.Fprintf(output, "    %s = true\n", meta.Key)
-				} else {
-					fmt.Fprintf(output, "    %s = false\n", meta.Key)
-				}
-			}
+	if len(rs.Includes) > 0 {
+		for _, include := range rs.Includes {
+			b.WriteString(fmt.Sprintf("include \"%s\"\n", include))
 		}
-		fmt.Fprintf(output, "\n")
+		b.WriteRune('\n')
 	}
-
-	if len(rule.Strings) > 0 {
-		fmt.Fprintf(output, "  strings:\n")
-		for _, s := range rule.Strings {
-			if s.Type == TypeString {
-				fmt.Fprintf(output, "    %s = \"%s\"", s.ID, s.Text)
-			} else if s.Type == TypeRegex {
-				fmt.Fprintf(output, "    %s = /%s/", s.ID, s.Text)
-			} else if s.Type == TypeHexString {
-				fmt.Fprintf(output, "    %s = { %s }", s.ID, s.Text)
-			}
-			if s.Modifiers.ASCII {
-				fmt.Fprintf(output, " ascii")
-			}
-			if s.Modifiers.Wide {
-				fmt.Fprintf(output, " wide")
-			}
-			if s.Modifiers.Nocase {
-				fmt.Fprintf(output, " nocase")
-			}
-			if s.Modifiers.Fullword {
-				fmt.Fprintf(output, " fullword")
-			}
-
-			if s.Modifiers.I {
-				fmt.Fprintf(output, "i")
-			}
-			if s.Modifiers.S {
-				fmt.Fprintf(output, "s")
-			}
-
-			fmt.Fprintf(output, "\n")
+	if len(rs.Imports) > 0 {
+		for _, imp := range rs.Imports {
+			b.WriteString(fmt.Sprintf("import \"%s\"\n", imp))
 		}
-		fmt.Fprintf(output, "\n")
+		b.WriteRune('\n')
 	}
 
-	fmt.Fprintf(output, "  condition:\n    %s\n}\n\n", rule.Condition)
+	for _, rule := range rs.Rules {
+		str, err := rule.Serialize()
+		if err != nil {
+			return "", err
+		}
+		b.WriteString(str)
+	}
+
+	out = b.String()
+
+	return
+}
+
+// Serialize for Rule builds a YARA rule as a string
+func (r *Rule) Serialize() (out string, err error) {
+	var b strings.Builder
+
+	// Rule modifiers
+	if r.Modifiers.Global {
+		b.WriteString("global ")
+	}
+	if r.Modifiers.Private {
+		b.WriteString("private ")
+	}
+
+	// Rule name
+	b.WriteString(fmt.Sprintf("rule %s ", r.Identifier))
+
+	// Any applicable tags
+	if len(r.Tags) > 0 {
+		b.WriteString(": ")
+		for _, t := range r.Tags {
+			b.WriteString(t)
+			b.WriteRune(' ')
+		}
+	}
+
+	// Start metas, strings, etc.
+	b.WriteString("{\n")
+
+	metas, err := r.Meta.Serialize()
+	if err != nil {
+		return
+	}
+	b.WriteString(metas)
+
+	strs, err := r.Strings.Serialize()
+	if err != nil {
+		return
+	}
+	b.WriteString(strs)
+
+	b.WriteString("condition:\n")
+	b.WriteString("  ") // TODO: Don't assume indent...
+	b.WriteString(r.Condition)
+	b.WriteString("\n}\n\n")
+
+	out = b.String()
+
+	return
+}
+
+// Serialize for Metas returns the "meta:" section in the YARA rule
+func (ms *Metas) Serialize() (out string, err error) {
+	if ms == nil || len(*ms) == 0 {
+		return
+	}
+
+	var b strings.Builder
+	b.WriteString("meta:\n")
+
+	for _, m := range *ms {
+		meta, e := m.Serialize()
+		if e != nil {
+			err = e
+			return
+		}
+		b.WriteString("  ") // TODO: make indent customizable
+		b.WriteString(meta)
+		b.WriteRune('\n')
+	}
+
+	out = b.String()
+	return
+}
+
+// Serialize for Meta returns the string representation of the key/value pair
+func (m *Meta) Serialize() (out string, err error) {
+	switch val := m.Val.(type) {
+	case string:
+		out = fmt.Sprintf(`%s = "%s"`, m.Key, val)
+
+	case int64, bool:
+		out = fmt.Sprintf(`%s = %v`, m.Key, val)
+
+	case float64:
+		// This is a bit tricky... val is interface{} and JSON unmarshals it
+		// as float64... So ensure decimal part is zero and treat as int64.
+		n := int64(val)
+		check := val - float64(n) // This should be 0.0 if it was int64
+		if check != 0.0 {
+			err = fmt.Errorf(`Unsupported meta value type "%T"`, val)
+			return
+		}
+		out = fmt.Sprintf(`%s = %v`, m.Key, val)
+
+	default:
+		err = fmt.Errorf(`Unsupported meta value type "%s"`, val)
+	}
+
+	return
+}
+
+// Serialize for Strings returns the "strings:" section in the YARA rule
+func (ss *Strings) Serialize() (out string, err error) {
+	if ss == nil || len(*ss) == 0 {
+		return
+	}
+
+	var b strings.Builder
+	b.WriteString("strings:\n")
+
+	for _, s := range *ss {
+		str, e := s.Serialize()
+		if e != nil {
+			err = e
+			return
+		}
+		b.WriteString("  ") // TODO: Make indent customizable
+		b.WriteString(str)
+		b.WriteRune('\n')
+	}
+
+	out = b.String()
+	return
+}
+
+// Serialize for String returns a String as a string
+func (s *String) Serialize() (out string, err error) {
+	// Format string for:
+	// `<identifier> = <encapsOpen> <text> <encapsClose> <modifiers>`
+	format := "%s = %s%s%s %s"
+
+	var (
+		encapsOpen  string
+		encapsClose string
+	)
+	switch t := s.Type; t {
+	case TypeString:
+		encapsOpen, encapsClose = `"`, `"`
+
+	case TypeHexString:
+		encapsOpen, encapsClose = "{", "}"
+
+	case TypeRegex:
+		encapsOpen = "/"
+		var closeBuilder strings.Builder
+		closeBuilder.WriteRune('/')
+		if s.Modifiers.I {
+			closeBuilder.WriteRune('i')
+		}
+		if s.Modifiers.S {
+			closeBuilder.WriteRune('s')
+		}
+		encapsClose = closeBuilder.String()
+
+	default:
+		err = fmt.Errorf("No such string type %s (%d)", t, t)
+		return
+	}
+
+	mods, _ := s.Modifiers.Serialize()
+
+	out = fmt.Sprintf(format, s.ID, encapsOpen, s.Text, encapsClose, mods)
+
+	return
+}
+
+// Serialize for StringModifiers creates a space-sparated list of
+// string modifiers, excluding the i and s which are appended to /regex/
+// The returned error must be nil.
+func (m *StringModifiers) Serialize() (out string, _ error) {
+	const modsAvailable = 4
+	modifiers := make([]string, 0, modsAvailable)
+	if m.ASCII {
+		modifiers = append(modifiers, "ascii")
+	}
+	if m.Wide {
+		modifiers = append(modifiers, "wide")
+	}
+	if m.Nocase {
+		modifiers = append(modifiers, "nocase")
+	}
+	if m.Fullword {
+		modifiers = append(modifiers, "fullword")
+	}
+
+	out = strings.Join(modifiers, " ")
+	return
 }


### PR DESCRIPTION
Changes allow you to re-create a YARA ruleset from a `data.RuleSet` struct.  All other structs can be serialized into their own components in a YARA rule, as well.